### PR TITLE
update to openssl 1.1.1, ruby 2.x API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
 
+# gem 'openssl', "~> 2.2.0"
+gem 'openssl', :path => "../ruby-openssl"
+
 # Specify your gem's dependencies in openssl-pkey-ec-ies.gemspec
 gemspec

--- a/ext/ies/ies.c
+++ b/ext/ies/ies.c
@@ -4,16 +4,16 @@ static VALUE eIESError;
 
 static EC_KEY *require_ec_key(VALUE self)
 {
-    const EVP_PKEY *pkey;
-    const EC_KEY *ec;
+    EVP_PKEY *pkey;
+    EC_KEY *ec;
     Data_Get_Struct(self, EVP_PKEY, pkey);
     if (!pkey) {
 	rb_raise(rb_eRuntimeError, "PKEY wasn't initialized!");
     }
-    if (EVP_PKEY_type(pkey->type) != EVP_PKEY_EC) {
+    if (EVP_PKEY_base_id(pkey) != EVP_PKEY_EC) {
 	rb_raise(rb_eRuntimeError, "THIS IS NOT A EC PKEY!");
     }
-    ec = pkey->pkey.ec;
+    ec = EVP_PKEY_get1_EC_KEY(pkey);
     if (ec == NULL)
 	rb_raise(eIESError, "EC_KEY is not initialized");
     return ec;
@@ -43,7 +43,7 @@ static cryptogram_t *ies_rb_string_to_cryptogram(const ies_ctx_t *ctx, const VAL
 
     size_t key_length = ctx->stored_key_length;
     size_t mac_length = EVP_MD_size(ctx->md);
-    const cryptogram_t *cryptogram = cryptogram_alloc(key_length, mac_length, data_len - key_length - mac_length);
+    cryptogram_t *cryptogram = cryptogram_alloc(key_length, mac_length, data_len - key_length - mac_length);
 
     memcpy(cryptogram_key_data(cryptogram), data, data_len);
 

--- a/ext/ies/ies.c
+++ b/ext/ies/ies.c
@@ -1,12 +1,15 @@
 #include "ies.h"
 
 static VALUE eIESError;
+extern const rb_data_type_t ossl_evp_pkey_type;
 
 static EC_KEY *require_ec_key(VALUE self)
 {
     EVP_PKEY *pkey;
     EC_KEY *ec;
-    Data_Get_Struct(self, EVP_PKEY, pkey);
+
+    TypedData_Get_Struct((self), EVP_PKEY, &ossl_evp_pkey_type, (pkey));
+
     if (!pkey) {
 	rb_raise(rb_eRuntimeError, "PKEY wasn't initialized!");
     }


### PR DESCRIPTION
Although I updated to openssl 1.1.1,  Data_Get_Struct(self, EVP_PKEY, pkey); does not work since the types are recorded now.

I tried to point at ossl_evp_pkey_type, but it is not exported from ruby-openssl's openssl.so.
It looks like this code needs to integrated into ruby-openssl now.
This pull request is really just to figure out if there is perhaps another way which I've missed.
